### PR TITLE
chore(pkg): add repository meta info

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "Demonstrates ES module loading in the browser",
   "main": "dist/browser-es-module-loader.js",
   "author": "Guy Bedford",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ModuleLoader/browser-es-module-loader"
+  },
   "license": "MIT",
   "devDependencies": {
     "babel-core": "^6.22.1",


### PR DESCRIPTION
Hi @guybedford 
Long time no see :)

Just adding repository info so we can have a like to this repo on https://www.npmjs.com/package/browser-es-module-loader 

See you :wave: 